### PR TITLE
[#7] Add support for dotenv files for development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,11 @@
+# Application
+APP_STAGE=dev
+APP_DEBUG=true
+APP_PORT=5000
+
+
+# Database
+PG_PORT=5432
+PG_DATABASE=outland-insights
+PG_USER=outland-insight-oltp
+PG_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 venv
 .idea
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This is a simple Flask web application that returns "Hello, World!" when accesse
 
 ### Running the Application
 
+**Update environment variables**
+```
+cp .env.template .env
+```
+
+Add a password for postgres and edit any other variables you would like.
+
 **Build & Run Services**
 ```
 docker compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-x-pg-database: &pg-database postgres
-x-pg-password: &pg-password mysecretpassword
-x-pg-user: &pg-user postgres
 name: backend
 services:
   database:
@@ -8,18 +5,18 @@ services:
     image: postgis/postgis:17-3.5-alpine
     restart: always
     ports:
-      - "5432:5432"
+      - "${PG_PORT}:5432"
     environment:
-      POSTGRES_DB: *pg-database
-      POSTGRES_USER: *pg-user
-      POSTGRES_PASSWORD: *pg-password
+      - POSTGRES_DB=${PG_DATABASE}
+      - POSTGRES_USER=${PG_USER}
+      - POSTGRES_PASSWORD=${PG_PASSWORD}
     networks:
       - backend-network
     volumes:
       - database-volume:/var/lib/postgresql/data
       - ./init-postgis.sql:/docker-entrypoint-initdb.d/init-postgis.sql
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DATABASE}" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -35,9 +32,6 @@ services:
       - "5000:5000"
     environment:
       PG_HOST: database
-      PG_DATABASE: *pg-database
-      PG_USER: *pg-user
-      PG_PASSWORD: *pg-password
     networks:
       - backend-network
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Jinja2==3.1.5
 loguru==0.7.3
 MarkupSafe==3.0.2
 psycopg2-binary==2.9.10
+python-decouple==3.8
 SQLAlchemy==2.0.37
 typing_extensions==4.12.2
 Werkzeug==3.1.3


### PR DESCRIPTION
- Added python-decouple
- Added .env.template to be used as .env example
- Changed docker-compose to use the .env values as well
- Update readme with instructions